### PR TITLE
Upgrade frameworks and dependencies

### DIFF
--- a/src/Highlight.Tests/Highlight.Tests.csproj
+++ b/src/Highlight.Tests/Highlight.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />

--- a/src/Highlight/Highlight.csproj
+++ b/src/Highlight/Highlight.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Version>8.1.0</Version>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Highlight/Highlight.csproj
+++ b/src/Highlight/Highlight.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <Version>8.1.0</Version>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Highlight/Highlight.csproj
+++ b/src/Highlight/Highlight.csproj
@@ -4,6 +4,6 @@
     <Version>8.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta0008" />
-  </ItemGroup> 
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta15" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR is a minor follow-up to #9.

I don't think we need to (or should) support legacy .NET any longer, therefore I'm removing the `net461` target framework. I've also bumped the .NET Core version from 2.0 to 3.1.

Finally, I've also bumped the SixLabors.Fonts dependency to version 1.0.0-beta15.