### PR TITLE
Disable auto-generation of AssemblyInfo metadata

### DIFF
--- a/src/Highlight.Tests/Highlight.Tests.csproj
+++ b/src/Highlight.Tests/Highlight.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />

--- a/src/Highlight/Highlight.csproj
+++ b/src/Highlight/Highlight.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1</TargetFrameworks>
-    <Version>8.1.0</Version>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta15" />


### PR DESCRIPTION
This PR disables auto-generation of AssemblyInfo metadata because we are already providing that ourselves in the `AssemblyInfo.cs` files in both projects.

We should probably consider moving to using auto-generation instead of relying on these old-school `AssemblyInfo.cs` files. However, I propose we do that in a separate PR.