### PR TITLE
Remove dependency to System.Drawing for cross-platform compatibility

### DIFF
--- a/src/Highlight/Configuration/XmlConfiguration.cs
+++ b/src/Highlight/Configuration/XmlConfiguration.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
@@ -23,7 +22,8 @@ namespace Highlight.Configuration
 
         public XmlConfiguration(XDocument xmlDocument)
         {
-            if (xmlDocument == null) {
+            if (xmlDocument == null)
+            {
                 throw new ArgumentNullException("xmlDocument");
             }
 
@@ -36,7 +36,8 @@ namespace Highlight.Configuration
 
         private IDictionary<string, Definition> GetDefinitions()
         {
-            if (definitions == null) {
+            if (definitions == null)
+            {
                 definitions = XmlDocument
                     .Descendants("definition")
                     .Select(GetDefinition)
@@ -70,13 +71,16 @@ namespace Highlight.Configuration
         {
             const StringComparison stringComparison = StringComparison.OrdinalIgnoreCase;
             var patternType = patternElement.GetAttributeValue("type");
-            if (patternType.Equals("block", stringComparison)) {
+            if (patternType.Equals("block", stringComparison))
+            {
                 return GetBlockPattern(patternElement);
             }
-            if (patternType.Equals("markup", stringComparison)) {
+            if (patternType.Equals("markup", stringComparison))
+            {
                 return GetMarkupPattern(patternElement);
             }
-            if (patternType.Equals("word", stringComparison)) {
+            if (patternType.Equals("word", stringComparison))
+            {
                 return GetWordPattern(patternElement);
             }
 
@@ -119,7 +123,8 @@ namespace Highlight.Configuration
         {
             var words = new List<string>();
             var wordElements = patternElement.Descendants("word");
-            if (wordElements != null) {
+            if (wordElements != null)
+            {
                 words.AddRange(from wordElement in wordElements select Regex.Escape(wordElement.Value));
             }
 
@@ -146,10 +151,11 @@ namespace Highlight.Configuration
         private Font GetPatternFont(XElement fontElement, Font defaultFont = null)
         {
             var fontFamily = fontElement.GetAttributeValue("name");
-            if (fontFamily != null) {
+            if (fontFamily != null)
+            {
                 var emSize = fontElement.GetAttributeValue("size").ToSingle(11f);
                 var style = Enum<FontStyle>.Parse(fontElement.GetAttributeValue("style"), FontStyle.Regular, true);
-                 
+
                 return SystemFonts.CreateFont(fontFamily, emSize, style);
             }
 
@@ -178,7 +184,8 @@ namespace Highlight.Configuration
         {
             var fontElement = patternElement.Descendants("font").Single();
             var element = fontElement.Descendants(descendantName).SingleOrDefault();
-            if (element != null) {
+            if (element != null)
+            {
                 var colors = GetPatternColors(element);
 
                 return colors;
@@ -209,8 +216,8 @@ namespace Highlight.Configuration
         {
             var fontName = fontElement.GetAttributeValue("name");
             var fontSize = Convert.ToSingle(fontElement.GetAttributeValue("size"));
-            var fontStyle = (FontStyle) Enum.Parse(typeof(FontStyle), fontElement.GetAttributeValue("style"), true);
-             
+            var fontStyle = (FontStyle)Enum.Parse(typeof(FontStyle), fontElement.GetAttributeValue("style"), true);
+
             return SystemFonts.CreateFont(fontName, fontSize, fontStyle);
         }
     }

--- a/src/Highlight/Engines/HtmlEngineHelper.cs
+++ b/src/Highlight/Engines/HtmlEngineHelper.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Drawing;
 using System.Text;
 using Highlight.Patterns;
 using SixLabors.Fonts;
@@ -27,26 +26,34 @@ namespace Highlight.Engines
         public static string CreatePatternStyle(ColorPair colors, Font font)
         {
             var patternStyle = new StringBuilder();
-            if (colors != null) {
-                if (colors.ForeColor != Color.Empty) {
+            if (colors != null)
+            {
+                if (colors.ForeColor != Color.Empty)
+                {
                     patternStyle.Append("color: " + colors.ForeColor.Name + ";");
                 }
-                if (colors.BackColor != Color.Empty) {
+                if (colors.BackColor != Color.Empty)
+                {
                     patternStyle.Append("background-color: " + colors.BackColor.Name + ";");
                 }
             }
 
-            if (font != null) {
-                if (font.Name != null) {
+            if (font != null)
+            {
+                if (font.Name != null)
+                {
                     patternStyle.Append("font-family: " + font.Name + ";");
                 }
-                if (font.Size > 0f) {
+                if (font.Size > 0f)
+                {
                     patternStyle.Append("font-size: " + font.Size + "px;");
                 }
-                if (font.Instance.Description.Style == FontStyle.Regular) {
+                if (font.Instance.Description.Style == FontStyle.Regular)
+                {
                     patternStyle.Append("font-weight: normal;");
                 }
-                if (font.Instance.Description.Style == FontStyle.Bold) {
+                if (font.Instance.Description.Style == FontStyle.Bold)
+                {
                     patternStyle.Append("font-weight: bold;");
                 }
             }

--- a/src/Highlight/Engines/RtfEngine.cs
+++ b/src/Highlight/Engines/RtfEngine.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -49,19 +48,23 @@ namespace Highlight.Engines
             var bracketStyle = CreateRtfPatternStyle(pattern.BracketColors.ForeColor, pattern.BracketColors.BackColor, pattern.Style.Font);
             string attributeNameStyle = null;
             string attributeValueStyle = null;
-            if (pattern.HighlightAttributes) {
+            if (pattern.HighlightAttributes)
+            {
                 attributeNameStyle = CreateRtfPatternStyle(pattern.AttributeNameColors.ForeColor, pattern.AttributeNameColors.BackColor, pattern.Style.Font);
                 attributeValueStyle = CreateRtfPatternStyle(pattern.AttributeValueColors.ForeColor, pattern.AttributeValueColors.BackColor, pattern.Style.Font);
             }
             builder.AppendFormat(RtfFormat, bracketStyle, match.Groups["openTag"].Value);
             builder.Append(match.Groups["ws1"].Value);
             builder.AppendFormat(RtfFormat, style, match.Groups["tagName"].Value);
-            if (attributeNameStyle != null) {
-                for (var i = 0; i < match.Groups["attribute"].Captures.Count; i++) {
+            if (attributeNameStyle != null)
+            {
+                for (var i = 0; i < match.Groups["attribute"].Captures.Count; i++)
+                {
                     builder.Append(match.Groups["ws2"].Captures[i].Value);
                     builder.AppendFormat(RtfFormat, attributeNameStyle, match.Groups["attribName"].Captures[i].Value);
 
-                    if (String.IsNullOrWhiteSpace(match.Groups["attribValue"].Captures[i].Value)) {
+                    if (String.IsNullOrWhiteSpace(match.Groups["attribValue"].Captures[i].Value))
+                    {
                         continue;
                     }
 
@@ -89,18 +92,21 @@ namespace Highlight.Engines
         private int GetIndexOfColor(Color color)
         {
             var color2 = new HexColor();
-            if (color.Name.IndexOf("#") > -1) {
+            if (color.Name.IndexOf("#") > -1)
+            {
                 color2.Red = Int32.Parse(color.Name.Substring(1, 2), NumberStyles.AllowHexSpecifier);
                 color2.Green = Int32.Parse(color.Name.Substring(3, 2), NumberStyles.AllowHexSpecifier);
                 color2.Blue = Int32.Parse(color.Name.Substring(5, 2), NumberStyles.AllowHexSpecifier);
             }
-            else {
+            else
+            {
                 color2.Red = color.R;
                 color2.Green = color.G;
                 color2.Blue = color.B;
             }
             var index = colors.IndexOf(color2);
-            if (index > -1) {
+            if (index > -1)
+            {
                 return (index + 1);
             }
             colors.Add(color2);
@@ -111,7 +117,8 @@ namespace Highlight.Engines
         private int GetIndexOfFont(string font)
         {
             var index = fonts.IndexOf(font);
-            if (index > -1) {
+            if (index > -1)
+            {
                 return (index + 1);
             }
             fonts.Add(font);
@@ -122,7 +129,8 @@ namespace Highlight.Engines
         private string BuildColorList()
         {
             var builder = new StringBuilder();
-            foreach (var hexColor in colors.Cast<HexColor>()) {
+            foreach (var hexColor in colors.Cast<HexColor>())
+            {
                 builder.AppendFormat(@"\red{0}\green{1}\blue{2};", hexColor.Red, hexColor.Green, hexColor.Blue);
             }
             return builder.ToString();
@@ -131,7 +139,8 @@ namespace Highlight.Engines
         private string BuildFontList()
         {
             var builder = new StringBuilder();
-            for (var i = 0; i < fonts.Count; i++) {
+            for (var i = 0; i < fonts.Count; i++)
+            {
                 builder.AppendFormat(@"\f{0} {1};", i, fonts[i]);
             }
             return builder.ToString();

--- a/src/Highlight/Patterns/Color.cs
+++ b/src/Highlight/Patterns/Color.cs
@@ -1,0 +1,57 @@
+using System.Globalization;
+
+// Replacement for System.Drawing.Color which is not available on non-Windows platforms
+namespace Highlight
+{
+    public class Color
+    {
+        public string Name { get; set; } // Either Hex or Web Color Name
+        public int R { get; set; }
+        public int G { get; set; }
+        public int B { get; set; }
+
+        public Color(string name, int r, int g, int b)
+        {
+            Name = name;
+            R = r;
+            G = g;
+            B = b;
+        }
+
+        public static Color Empty = new Color("#FFFFFF", 0, 0, 0);
+
+        public static Color FromName(string name)
+        {
+            // Todo: Add extended colors from https://en.wikipedia.org/wiki/Web_colors#HTML_color_names
+            if (name.IndexOf("#") == -1)
+            {
+                name = name switch
+                {
+                    "white" => "#FFFFFF",
+                    "silver" => "#C0C0C0",
+                    "gray" => "#808080",
+                    "black" => "#000000",
+                    "red" => "#FF0000",
+                    "maroon" => "#800000",
+                    "yellow" => "#FFFF00",
+                    "olive" => "#808000",
+                    "lime" => "#00FF00",
+                    "green" => "#008000",
+                    "aqua" => "#00FFFF",
+                    "teal" => "#008080",
+                    "blue" => "#0000FF",
+                    "navy" => "#000080",
+                    "fuchsia" => "#FF00FF",
+                    "purple" => "#800080",
+                    _ => throw new System.Exception("Unknown color name: " + name),
+                };
+            }
+
+            int red = int.Parse(name.Substring(1, 2), NumberStyles.AllowHexSpecifier);
+            int green = int.Parse(name.Substring(3, 2), NumberStyles.AllowHexSpecifier);
+            int blue = int.Parse(name.Substring(5, 2), NumberStyles.AllowHexSpecifier);
+
+            return new Color(name, red, green, blue);
+        }
+    }
+}

--- a/src/Highlight/Patterns/Color.cs
+++ b/src/Highlight/Patterns/Color.cs
@@ -18,7 +18,7 @@ namespace Highlight
             B = b;
         }
 
-        public static Color Empty = new Color("#FFFFFF", 0, 0, 0);
+        public static Color Empty = new Color("#FFFFFF", 255, 255, 255);
 
         public static Color FromName(string name)
         {

--- a/src/Highlight/Patterns/ColorPair.cs
+++ b/src/Highlight/Patterns/ColorPair.cs
@@ -1,5 +1,3 @@
-using System.Drawing;
-
 namespace Highlight.Patterns
 {
     public class ColorPair

--- a/src/Highlight/Patterns/Style.cs
+++ b/src/Highlight/Patterns/Style.cs
@@ -1,4 +1,3 @@
-using System.Drawing;
 using SixLabors.Fonts;
 
 namespace Highlight.Patterns


### PR DESCRIPTION
System.Drawing is only supported in Windows environments.

This PR replaced the Color class from System.Drawing with a standalone implementation and removes the `System.Drawing` usings.

The IDE formatted some code that slipped into the PR.